### PR TITLE
Bundle install command fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ If you're using pathogen, extract the file into `bundle` directory.
 ### Using Vundle
 Just add the following line in the Vundle part of your vimrc
 
-    Plugin 'KabbAmine/zeavim.vim'
+    Bundle 'KabbAmine/zeavim.vim'
 
 Then proceed to the installation of the plugin with the following command:
 
-    :PluginInstall
+    :BundleInstall
 
 
 Usage


### PR DESCRIPTION
In my environment the Vundle plugins are added with the Bundle keyword in .vimrc, and the command to install is :BundleInstall
