### PR TITLE
detect docsets folder; rename g:zv_zeal_directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ Customization <a id="customization"></a>
 
 ### Location of Zeal
 
-By default zeavim assumes that *zeal* is located in `%ProgramFiles/Zeal/zeal.exe` for Windows and `/usr/bin/zeal` for UNIX systems.
+By default zeavim looks for an executable named `zeal` on your system.  If that fails, zeavim assumes that *zeal* is located in `%ProgramFiles%/Zeal/zeal.exe` for Windows and `/usr/bin/zeal` for UNIX systems.
 You can specify Zeal's location manually by adding in your vimrc:
 
     if has('win32') || has('win64')
-        let g:zv_zeal_directory = " path\\to\\zeal.exe\""
+        let g:zv_zeal_executable = "path\\to\\zeal.exe"
     else
-        let g:zv_zeal_directory = "/usr/bin/zeal"
+        let g:zv_zeal_executable = "/usr/bin/zeal"
     endif
 
 ### Add file types
@@ -140,7 +140,7 @@ When using `<leader><leader>z` or the command `Docset`, you can get a docset nam
 
 There are 2 ways to enable that:
 
-1. The docset names can be taken from your zeal's docset directory (The one specified in Zeal's options), just set the correct path in `g:zv_docsets_dir` in your vimrc:
+1. The docset names can be taken from your zeal's docset directory (The one specified in Zeal's options), just set the correct path in `g:zv_docsets_dir` in your vimrc (by default zeavim assumes that Zeal docsets are located in `%LOCALAPPDATA%\Local\Zeal\Zeal\docsets`, which expands into something like `C:\Users\you\AppData\Local\Zeal\Zeal\docsets`, for Windows and `~/.local/share/Zeal/Zeal/docsets` for UNIX systems):
 
 	```
 	if has('win32') || has('win64')

--- a/doc/zeavim.txt
+++ b/doc/zeavim.txt
@@ -142,12 +142,12 @@ To revert that and get zeavim working like usually, a simple `Docset` without ar
 6.1. Zeal's location~
 *zeavim-settings:location*
 
-By default zeavim assume that `zeal` is located in `%ProgramFiles/Zeal/zeal.exe` for Windows and `/usr/bin/zeal` for UNIX systems.
+By default zeavim looks for an executable named `zeal` on your system.  If that fails, zeavim assumes that `zeal` is located in `%ProgramFiles%/Zeal/zeal.exe` for Windows and `/usr/bin/zeal` for UNIX systems.
 You can specify Zeal's location manually by adding in your vimrc: >
     if has('win32') || has('win64')
-	    let g:zv_zeal_directory = " path\\to\\zeal.exe\""
+	    let g:zv_zeal_executable = "path\\to\\zeal.exe"
     else
-	    let g:zv_zeal_directory = "/usr/bin/zeal"
+	    let g:zv_zeal_executable = "/usr/bin/zeal"
     endif
 
 ------------------------------------------------------------------------
@@ -184,7 +184,7 @@ When using `<leader><leader>z` or the command `Docset`, you can get a docset nam
 
 There are 2 ways to enable that:
 
-1. The docset names can be taken from your zeal's docset directory (The one specified in Zeal's options), just set the correct path in `g:zv_docsets_dir` in your vimrc: >
+1. The docset names can be taken from your zeal's docset directory (The one specified in Zeal's options), just set the correct path in `g:zv_docsets_dir` in your vimrc (by default zeavim assumes that Zeal docsets are located in `%LOCALAPPDATA%\Local\Zeal\Zeal\docsets`, which expands into something like `C:\Users\you\AppData\Local\Zeal\Zeal\docsets`, for Windows and `~/.local/share/Zeal/Zeal/docsets` for UNIX systems): >
     if has('win32') || has('win64')
 	let g:zv_docsets_dir = 'path\\to\\docsets\\directory\\'
     else

--- a/plugin/zeavim.vim
+++ b/plugin/zeavim.vim
@@ -73,20 +73,28 @@ command! -complete=custom,CompleteDocsetName -nargs=? Docset :let b:manualDocset
 " VARIABLES
 " =====================================================================
 
-" Set Zeal's Location {{{1
-	if !exists('g:zv_zeal_directory')
-		if has('win32') || has('win64')
-			let g:zv_zeal_directory = $ProgramFiles."/Zeal/zeal.exe"
-		else
-			let g:zv_zeal_directory = "/usr/bin/zeal"
+" Set Zeal's Executable Location {{{1
+	if !exists('g:zv_zeal_executable')
+		if executable('zeal')
+			let g:zv_zeal_executable = 'zeal'
+		elseif has('unix')
+			let g:zv_zeal_executable = '/usr/bin/zeal'
+		elseif has('win32') || has('win64')
+			let g:zv_zeal_executable = $ProgramFiles."/Zeal/zeal.exe"
 		endif
 	endif
-" Set Zeal's execution command {{{1
-	if has('win32')
-		let s:zealExecCmd = '!start "' . g:zv_zeal_directory . '" '
-	else
-		let s:zealExecCmd = '! ' . g:zv_zeal_directory . ' '
+" }}}
+
+" Set Zeal's Docset Directory Location {{{1
+	if !exists('g:zv_docsets_dir')
+		if has('unix')
+			let g:zv_docsets_dir = expand('~/.local/share/Zeal/Zeal/docsets')
+		elseif has('win32') || has('win64')
+			let g:zv_docsets_dir = $LOCALAPPDATA . '/Zeal/Zeal/docsets'
+		endif
 	endif
+" }}}
+
 " A dictionary who contains the docset names of some file extensions {{{1
 	let s:zeavimDocsetNames = {
 				\ 'cpp': 'c++',
@@ -165,9 +173,9 @@ endfunction
 " ************************
 function s:CheckZeal() " {{{1
 	" Check if the Zeal's executable is present according to the global
-	" variable zv_zeal_directory and return 0 if not
+	" variable zv_zeal_executable and return 0 if not
 
-	if !executable(g:zv_zeal_directory)
+	if !executable(g:zv_zeal_executable)
 		call s:ShowMessage(4, "Zeal is not present in your system or his location is not defined")
 		return 0
 	else
@@ -194,13 +202,8 @@ endfunction
 function s:GetDocsetNameFromDir(directory) " {{{1
 	" Get docset names from zeal docset directory.
 
-	let l:docsetList = glob(a:directory . '*.docset', 0, 1)
-	for l:index in range(0, len(l:docsetList) - 1)
-		let l:docsetList[l:index] = substitute(l:docsetList[l:index], '^.*\(/\|\\\)\([A-Za-z0-9_]\+\)\.docset$', '\2', 'g')
-		let l:docsetList[l:index] = substitute(l:docsetList[l:index], '_', ' ', 'g')
-		let l:docsetList[l:index] = tolower(l:docsetList[l:index])
-	endfor
-	return l:docsetList
+	return map(glob(a:directory . '/*.docset', 0, 1),
+		\ 'tolower(tr(fnamemodify(v:val, ":t:r"), "_", " "))')
 
 endfunction
 function s:GetDocsetName() " {{{1
@@ -227,13 +230,13 @@ function s:ExecuteZeal(docsetName, selection) " {{{1
 
 	let l:docsetName = a:docsetName != '' ? a:docsetName . ':' : ''
 	let l:selection = a:selection != '' ? a:selection : ''
-	let s:executeZeal = 'silent :' . s:zealExecCmd . '"' . l:docsetName . l:selection . '"'
-	if has ('win32')
-		execute s:executeZeal . ' > NUL'
-	else
-		execute s:executeZeal . ' 2> /dev/null &'
+	let l:command = g:zv_zeal_executable . ' ' . shellescape(l:docsetName . l:selection)
+	if has('unix')
+		let l:command = l:command . ' &'
+	elseif has('win32') || has('win64')
+		let l:command = 'start /B ' . l:command . ' > NUL'
 	endif
-	redraw!
+	silent call system(l:command)
 
 endfunction
 " }}}


### PR DESCRIPTION
First, this patch adds detection of Zeal's docsets directory location
and documents the existing `g:zv_docsets_dir` variable in the README.

Second, this patch renames the `g:zv_zeal_directory` variable to
`g:zv_zeal_executable` because its value is the path of the Zeal
executable, not the directory which contains the Zeal executable.

Finally, this patch simplifies the implementation of functions:
CompleteDocsetName(), GetDocsetNameFromDir(), and GetDocsetName().
Notably, I used system() with shellescape() instead of `:!` syntax,
which has the advantage of not requiring `redraw!` and also dynamically
finds the "zeal" executable in the system's path in a portable fashion.
