### PR TITLE
Remove mapping from `ft=cpp` to `c++`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ You can add arguments/flags to zeal command using `g:zv_zeal_args`.
 By default, the plugin defines a few docsets:
 
 ```vim
-'cpp' : 'c++'
 'scss': 'sass'
 'sh'  : 'bash'
 'tex' : 'latex'

--- a/autoload/zeavim.vim
+++ b/autoload/zeavim.vim
@@ -22,7 +22,6 @@ if !exists('g:zv_docsets_dir')
 endif
 " A dictionary containing the docset names of some file extensions {{{1
 let s:docsetsDic = {
-			\	'cpp' : 'c++',
 			\	'scss': 'sass',
 			\	'sh'  : 'bash',
 			\	'tex' : 'latex',

--- a/doc/zeavim.txt
+++ b/doc/zeavim.txt
@@ -172,7 +172,6 @@ default)
 
 By default, the plugin defines a few docsets:
 >
-    cpp : c++
     scss: sass
     sh  : bash
     tex : latex


### PR DESCRIPTION
In my zeal v.0.4.0 the `C++` docs are associated to the string `cpp` not `c++` so this mapping is not necessary.