### PR TITLE
refine logic in func 's:GetDocset()' -and- add a note about 'g:zv_get_docset_by'

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Please refer to the [doc file](./doc/zeavim.txt) for a full description of the o
   let g:zv_get_docset_by = ['ext', 'file', 'ft']
   ```
 
+  to guess docset is by pattern matching, the item & its order is a matter.
+
 ----------
 
 * `g:zv_docsets_dir` - Directory where are stored zeal's docsets for command completion purpose.

--- a/autoload/zeavim.vim
+++ b/autoload/zeavim.vim
@@ -141,10 +141,9 @@ function! s:GetDocset(file, ext, ft) abort " {{{1
         for l:k in keys(s:docsetsDic)
             if match(a:{l:t}, l:k) ==# 0
                 let l:docset = s:docsetsDic[l:k]
-                break
-            endif
-            if !empty(l:docset)
-                break
+                if !empty(l:docset)
+                    return l:docset
+                endif
             endif
         endfor
     endfor
@@ -168,7 +167,7 @@ function! s:SetDocset() abort " {{{1
 
     let l:docset = !empty(getbufvar('%', 'manualDocset'))
                 \ ? getbufvar('%', 'manualDocset')
-                \ :s:GetDocset(expand('%:p:t'), expand('%:e:e'), &ft)
+                \ : s:GetDocset(expand('%:p:t'), expand('%:p:e'), &ft)
     return tolower(l:docset)
 endfunction
 " 1}}}

--- a/doc/zeavim.txt
+++ b/doc/zeavim.txt
@@ -248,6 +248,8 @@ You can set a specific order or remove a criteria: >
     " and finally to the type.
     let g:zv_get_docset_by = ['ext', 'file', 'ft']
 
+Note to guess docset is by pattern matching, the item & its order is a matter.
+
 ------------------------------------------------------------------------
 6.6. Docset name completion~
 *zeavim-settings:docset-completion*


### PR DESCRIPTION
1, for example in `function! s:GetDocset(file, ext, ft)`:
`l:t` file is 'sh_foo_.py'
`l:k` key is 'sh'
then `if match(a:{l:t}, l:k) ==# 0` was accidently matched .. but 'sh_foo_.py' is a 'py' not a 'sh' ! 
// adding a note to readme and doc.

2, as long as that matched -and- l:docset was not empty, then it did not need to do next/left loop anymore ..
// just return it.